### PR TITLE
Pipe redesign

### DIFF
--- a/example/args.cpp
+++ b/example/args.cpp
@@ -1,0 +1,10 @@
+#include <process>
+
+int main()
+{
+    std::process p(std::this_process::environment::find_executable("test.exe"), {"--foo", "/bar"});
+
+    p.wait();
+    
+    return p.exit_code();
+}

--- a/example/async_io.cpp
+++ b/example/async_io.cpp
@@ -1,0 +1,28 @@
+#include <process>
+#include <pstream>
+#include <executor>
+#include <buffer>
+#include <string>
+#include <iostream>
+
+int main()
+{
+    std::net::executor exec;
+    std::net::streambuf buffer;
+  
+    std::async_pipe ap(exec);
+
+    std::process p(
+        std::this_process::environment::find_executable("test.exe"),
+        std::process_io(ap, {}, {});
+        
+
+    auto read_future = std::net::async_read(ap, buffer, std::use_future_t());
+    auto exec_future = p.async_wait(exec, std::use_future_t());
+
+    exec.context().run();
+    
+    std::cout << "Read " << read_future.get() << bytes << std::endl;
+    
+    return exec_future.get();
+}

--- a/example/env.cpp
+++ b/example/env.cpp
@@ -1,0 +1,36 @@
+#include <process>
+#include <filesystem>
+#include <environment>
+#include <string>
+#include <cctype>
+
+template<typename String>
+std::string to_upper(String && str)
+{
+    std::string res = std::forward<String>(str);
+    for (auto & c : res)
+        c = std::toupper(c);
+
+    return res;
+}
+
+int main()
+{
+    std::environment my_env = std::this_process::environment::native_environment();
+
+    std::filesystem::path additional_path = "/foo";
+
+    keys = my_env.keys();
+    auto path_key = std::find_if(keys.begin(), keys.end(), [] (auto & val) {return to_upper<std::string>(val) == "PATH";});
+
+    
+    const paths = my_env.get(path_key).as_vector();
+
+    paths.push_back(additional_path);
+    
+    my_env.set(path_key, paths);
+    std::process proc(my_env.find_executable("test.exe"), my_env);
+    proc.wait();
+    
+    return proc.exit_code();
+}

--- a/example/error_handling.cpp
+++ b/example/error_handling.cpp
@@ -1,0 +1,14 @@
+#include <process>
+#include <system_error>
+
+int main()
+{
+    try 
+    {
+        std::process proc("does-not-exist", {});
+    }
+    catch (process_error & pe)
+    {
+        std::cout << "Process launch error for file: " << pe.path() << std::endl;
+    }
+}

--- a/example/intro.cpp
+++ b/example/intro.cpp
@@ -1,0 +1,16 @@
+#include <process>
+#include <pstream>
+
+int main()
+{
+    std::ipstream pipe_stream;
+    std::process c("/usr/bin/gcc" {"--version",} std::process_io({} ,pipe_stream, {}));
+
+    std::string line;
+
+    while (pipe_stream && std::getline(pipe_stream, line) && !line.empty())
+        std::cerr << line << std::endl;
+
+    c.wait();
+    return c.exit_code();
+}

--- a/example/posix.cpp
+++ b/example/posix.cpp
@@ -1,0 +1,21 @@
+#include <process>
+
+int main()
+{
+    struct chroot
+    {
+        const char * root_to;
+        
+        template<ProcessLauncher Launcher>
+        void on_exec_setup(Launcher&)
+        { 
+            ::chroot(root_to); 
+        };
+        
+    };
+    
+    std::process proc("./test", {}, chroot("/new/root/directory/"));
+    proc.wait();
+    
+    return proc.exit_code();
+}

--- a/example/start_dir.cpp
+++ b/example/start_dir.cpp
@@ -1,0 +1,15 @@
+#include <process>
+#include <filesystem>
+
+int main()
+{
+    std::filesystem::path exe = "test.exe";
+    std::process proc(
+        std::filesystem::absolute(exe),
+        {},
+        std::process_start_dir="../foo"
+    );
+    
+    proc.wait();
+    return proc.exit_code();
+}

--- a/example/terminate.cpp
+++ b/example/terminate.cpp
@@ -1,0 +1,7 @@
+#include <process>
+
+int main()
+{
+    std::process p(std::this_process::environment::find_executable("test.exe"));
+    c.terminate();
+}

--- a/example/wait.cpp
+++ b/example/wait.cpp
@@ -1,0 +1,24 @@
+#include <process>
+#include <executor>
+#include <environment>
+
+int main()
+{
+    {
+        std::process c(std::this_environment::find_executable("test.exe"), {});
+        c.wait();
+        auto exit_code = c.exit_code();
+    }
+
+    {
+        std::executor::executor executor;
+
+        std::process c(
+            std::this_environment::find_executable("test.exe"),
+            executor,
+            bp::on_exit([&](int exit, const std::error_code& ec_in){})
+        );
+
+        executor.context().run();
+    }
+}

--- a/example/windows.cpp
+++ b/example/windows.cpp
@@ -1,0 +1,30 @@
+#include <process>
+#include <iostream>
+
+#include <windows.h>
+
+int main()
+{
+    const auto exe = std::this_process::environment::find_executable("test.exe");
+    struct start_fullscreeen
+    {
+        template<std::ProcessLauncher Launcher>
+        void on_setup(Launcher & l)
+        {
+            l.startup_info.wShowWindow  = SHOW_WINDOW; // < implementation defined.
+        }
+    };
+
+    struct show_window
+    {
+        template<std::ProcessLauncher Launcher>
+        void on_setup(Launcher & l)
+        {
+            l.startup_info.dwFlags = STARTF_RUNFULLSCREEN; // < implementation defined.
+        }
+    };
+        
+    
+    std::process proc1(exe, {}, show_window());
+    std::process proc2(exe, {}, start_fullscreeen());
+}

--- a/process_proposal.org
+++ b/process_proposal.org
@@ -450,8 +450,22 @@ class process_group
     bool valid() const;
     explicit operator bool() const; //equivalent to this->valid()
 
-
     //Process Management Functions
+
+    
+    //Emplace a process into the group, i.e. launch it attached to the group
+    template<ProcessInitializer ...Inits>
+    pid_t emplace(const std::filesystem::path & exe, const Range<std::string> & args, Inits&&...inits);
+
+    //Emplace a process into the group, i.e. launch it attached to the group with a custom process launcher
+    template<ProcessInitializer ...Inits, ProcessLauncher Launcher>
+    pid_t emplace(const std::filesystem::path & exe, const Range<std::string> & args, Inits&&...inits, Launcher && launcher);
+
+    //Attach an existing process to the group. The process object will be empty afterwads
+    pid_t attach(std::proces && proc);
+
+    //Take a process out of the group
+    std::process [[nodiscard]] detach(pid_t);
 
     // detach a process group -- let it run after this handle destructs
     void detach();
@@ -1426,6 +1440,55 @@ auto fut = proc.async_wait(exec, std::net::use_future_t());
 const exit_code = fut.get();
 assert(exit_code == proc.exit_code());
 #+END_SRC
+
+** Class ~process_group~
+
+The process group can be used for managing several processes at once. Because of the underlying implementation on the OS, there is no guarantee that the exit-code for a process can be obtained. Because of this the `wait_one` and related functions do not yield the exit_code or pid. To make workaround easy, the launch function returns the pid, so a user can write his own code.
+
+*** Example: Attaching a debugger to a process and grouping them.
+
+#+BEGIN_SRC c++
+
+std::process_group grp;
+
+auto pid_target = grp.emplace("./my_proc", {});
+auto pid_gdb = grp.emplace("/usr/bin/gdb", {-p, std::to_string(pid_target)});
+//do something
+
+//kill gdb and use the process individually:
+
+grp.detach(pid_gdb).terminate();
+std::process target = grp.detach(pid_target); 
+
+#+END_SRC
+
+*** Example: Having a worker, e.g. for a build system
+
+#+BEGIN_SRC c++
+
+void run_all(const std::queue<std::pair<std::filesystem::path, std::vector<std::string>>> & jobs, int parallel = 4)
+{
+    std::process_group grp;
+    for (auto idx = 0u; (idx < parallel) && !jobs.empty(); idx++)
+    {
+        const auto [exe, args] = jobs.front();
+        grp.emplace(exe, args);
+        jobs.pop();
+    }
+
+    while (!jobs.empty())
+    {
+        grp.wait_one();
+        const auto [exe, args] = jobs.front();
+        grp.emplace(exe, args);
+        jobs.pop();
+    }
+
+}
+
+#+END_SRC
+
+
 
 * Open Questions
 ** if we don't have wait_for can we still detach? 

--- a/process_proposal.org
+++ b/process_proposal.org
@@ -1584,6 +1584,70 @@ std::process proc("./foo", {}, std::process_io(std::process_io::null(), std::pro
 
 #+END_SRC
 
+** Class ~environment~
+
+*** ~operator[]~
+
+Unlike Muerte's proposal, ours does not contain an ~operator[]~. The reason is that environment variables are not uniform on their handling of case-sensitivity. For example ~"PATH"~ might be ~"Path"~ between different versions of windows. However, both maybe defined on windows. This can cause a problem:
+
+#+BEGIN_SRC c++
+std::environment env = std::this_process::environment::native_environment();
+
+//let's say it's "Path", but we expect "PATH"
+env["PATH"].add_value("C:\\python");
+std::process proc (env.find_executable("python"), {"./my_script.py"}, env); //error -> python not found or ambiguity error.
+
+#+END_SRC
+
+If we however have it explicitly, things are more obvious.
+
+#+BEGIN_SRC c++
+std::string to_upper(const std::string & in); //implement a conversion to upper case here
+
+auto keys = env.keys(); 
+auto path_key = std::find_if(keys.begin(), keys.end(), [](auto & str) {return to_upper(str) == "PATH";});
+
+auto entry = env.get(path_key); 
+
+auto val = entry.as_vector();
+val.push_back("C:\\python");
+env.set(path_key, val);
+
+#+END_SRC
+
+*** Function ~environment::home()~
+
+This should be it's own function, because it is one value on posix (~"HOME"~) but two on windows (~"HOME_DRIVE"~, ~"HOME_DIR"~).
+
+*** Function ~environment::extensions~
+
+This environment variable is only used on systems that use file extensions to determine executables (i.e. windows).
+
+#+BEGIN_SRC
+//assume /home/hello_world.py is the executable and "/home" is in PATH already --> It's names hello_world on linux, hello_world.py on windows.
+std::environment env = std::this_process::environment::native_environment();
+auto extensions = env.extensions();
+
+std::process proc;
+
+if (std::find(extensions.begin(), extensions.end(), ".py")) //we can use find_executable -> on linux only if the file does not have the syntax. This is in accordance with the shell rules
+    proc = std::process(env.find_executable("hello_world"), {});
+else
+    proc = std::process("/home/hello_world.py", {});
+
+#+END_SRC
+
+*** Function ~environment::find_executable~
+
+This function shall find an executable with the name. if the OS uses file extensions it shall compare those, if not it shall check the executable flag.
+
+#+BEGIN_SRC
+
+auto pt = std::this_process::environment::find_executable("readme.txt"); //finds a file, but is not executable
+assert(pt.empty());
+
+#+END_SRC
+
 * Open Questions
 ** if we don't have wait_for can we still detach? 
 

--- a/process_proposal.org
+++ b/process_proposal.org
@@ -1488,7 +1488,101 @@ void run_all(const std::queue<std::pair<std::filesystem::path, std::vector<std::
 
 #+END_SRC
 
+** Class ~process_io~
 
+~process_io~ takes the three standard handles, because some OS (windows that is) does not allow to cherry-pick those. Either all three are set or all are defaults.
+
+The default of course is to forward it to ~std*~.
+
+*** Using pipes
+
+#+BEGIN_SRC c++
+
+std::pipe pin, pout, perr;
+std::process proc("foo", {}, std::process_io(pin, pout, perr));
+
+pin.write("bar", 4);
+
+#+END_SRC
+
+Forwarding between processes:
+
+#+BEGIN_SRC
+
+std::system("./proc1 | ./proc2");
+
+std::optional<std::pipe> fwd = std::pipe();
+
+std::process proc1("./proc1", {}, std::process_io({}, *fwd, {});
+std::process proc2("./proc1", {}, std::process_io(*fwd, {}, {});
+
+fwd = std::nullopt; //not needed anymore
+
+#+END_SRC
+
+You can of course use any ~pstream~ type instead.
+
+*** Using files
+
+#+BEGIN_SRC c++
+
+std::filesystem::path log_path = std::this_process::environment::home() / "my_log_file";
+std::system("foo > ~/my_log_file");
+//equivalent:
+std::process proc ("foo", std::process_io({}, log_path , {}));
+
+#+END_SRC
+
+With an extension to fstream:
+
+#+BEGIN_SRC c++
+
+std::ifstream fs{"/my_log_file"};
+std::process proc ("./foo", std::process(fs, {}, {});
+
+#+END_SRC
+
+*** ~std::this_process::stdio~
+
+Since ~std::cout~ can be redirected programmatically and has the same type as ~std::cerr~ it does not seem like a proper fit, unless it's type is changed 
+
+#+BEGIN_SRC c++
+//redirect stderr to stdout
+std::process proc ("./foo", std::process_io({}, {}, std::this_process::io().stdout());
+#+END_SRC
+
+*** Closing streams
+
+A closed stream means that the child process cannot read or write from the stream. That is, an attempt to do so yields an error. This can be done by using ~nullptr~.
+
+#+BEGIN_SRC c++
+std::process proc ("./foo", std::process_io(nullptr, nullptr, nullptr));
+#+END_SRC
+
+
+*** Other objects 
+
+Other objects, that use an underlying stream handle, shall be used. This is the case for tcp sockets (i.e. ~std::net::basic_stream_socket~).
+
+#+BEGIN_SRC c++
+
+std::net::tcp::socket sock(...) 
+//connect the socket
+
+std::process proc ("./server", std::process_io(socket, socket, "log-file"));
+#+END_SRC
+
+*** Null device (not yet specified)
+
+The null-device is a a feature of both posix ("/dev/null") and windows ("NUL"). It accepts and write, and always returns It might be worth considering adding it.
+
+#+BEGIN_SRC
+
+std::system("./foo > /dev/null");
+
+std::process proc("./foo", {}, std::process_io(std::process_io::null(), std::process_io::null(), std::process_io::null()));
+
+#+END_SRC
 
 * Open Questions
 ** if we don't have wait_for can we still detach? 

--- a/process_proposal.org
+++ b/process_proposal.org
@@ -907,14 +907,14 @@ public:
     typedef typename Traits::off_type  off_type   ;
     typedef implementation-defined native_handle;
     
-    typedef basic_pipe_read_end<CharT, Traits> sink_type;
-    typedef basic_pipe_read_end<CharT, Traits> source_type;
+    typedef basic_pipe_read_end<CharT, Traits> read_end_type;
+    typedef basic_pipe_write_end<CharT, Traits> write_end_type;
 
     ///Construct the pipe from two ends that are duplicated
-    basic_pipe(const source_type & source, const sink_type & sink);
+    basic_pipe(const read_end_type & read_end, const write_end_type & write_end);
 
     ///Construct the pipe from two ends that are moved
-    basic_pipe(source_type && source, sink_type && sink);
+    basic_pipe(read_end_type && read_end, write_end_type && write_end);
 
     /// Default construct the pipe. Will be opened.
     basic_pipe();

--- a/process_proposal.org
+++ b/process_proposal.org
@@ -540,7 +540,7 @@ class process_io
   //construct 
   template<typename In = in_default, typename Out = out_default, typename Err = err_default> 
   /* requires In to be ReadableStream, Out & Err to be WritableStream. 
-  This is to be defined, but should allow any stream that can yield a system-handle (e.g. pipes, files & sockets) and to close the stream by passing nullptr. 
+  This is to be defined, but should allow any stream that can yield a system-handle (e.g. pipe_ends, files & sockets) and to close the stream by passing nullptr. 
   Additionally a path should be possible to open a file just for the child process.
   */  
   process_io(In && in, Out && out, Err && err);
@@ -696,6 +696,205 @@ This is just the outline of the pipe header. It could be part of the <process> h
 
 namespace std {
 
+template<class CharT, class Traits = std::char_traits<CharT>>
+class basic_pipe_read_end;
+
+typedef basic_pipe_read_end<char>     pipe_read_end;
+typedef basic_pipe_read_end<wchar_t> wpipe_read_end;
+
+template<class CharT, class Traits = std::char_traits<CharT>>
+class basic_pipe_write_end;
+
+typedef basic_pipe_write_end<char>     pipe_write_end;
+typedef basic_pipe_write_end<wchar_t> wpipe_write_end;
+
+template<class CharT, class Traits = std::char_traits<CharT>>
+class basic_pipe;
+
+typedef basic_pipe<char>     pipe;
+typedef basic_pipe<wchar_t> wpipe;
+
+template<class CharT, class Traits> struct tuple_size<basic_pipe<Char, Traits>> {constexpr static std::size_t size = 2;};
+template<class CharT, class Traits> struct tuple_element<0, basic_pipe<Char, Traits>>  { using type = basic_pipe_read_end <CharT, Traits>; };
+template<class CharT, class Traits> struct tuple_element<1, basic_pipe<Char, Traits>>  { using type = basic_pipe_write_end<CharT, Traits>; };
+
+template<std::size_t Index, class CharT, class Traits> auto get(      basic_pipe<Char, Traits> &&);
+template<std::size_t Index, class CharT, class Traits> auto get(const basic_pipe<Char, Traits>  &);
+
+template<class CharT, class Traits> basic_pipe_read_end<CharT, Traits> get<0>(const basic_pipe<Char, Traits> &);
+template<class CharT, class Traits> basic_pipe_read_end<CharT, Traits> get<0>(      basic_pipe<Char, Traits> &&);
+
+template<class CharT, class Traits> basic_pipe_write_end<CharT, Traits> get<1>(const basic_pipe<Char, Traits> &);
+template<class CharT, class Traits> basic_pipe_write_end<CharT, Traits> get<1>(      basic_pipe<Char, Traits> &&);
+
+
+template<class CharT, class Traits = std::char_traits<CharT>>
+struct basic_pipebuf;
+typedef basic_pipebuf<char>     pipebuf;
+typedef basic_pipebuf<wchar_t> wpipebuf;
+
+template<class CharT, class Traits = std::char_traits<CharT>>
+class basic_ipstream;
+typedef basic_ipstream<char>     ipstream;
+typedef basic_ipstream<wchar_t> wipstream;
+
+template<class CharT, class Traits = std::char_traits<CharT>>
+class basic_opstream;
+typedef basic_opstream<char>     opstream;
+typedef basic_opstream<wchar_t> wopstream;
+
+template<class CharT, class Traits = std::char_traits<CharT>>
+class basic_pstream;
+typedef basic_pstream<char>     opstream;
+typedef basic_pstream<wchar_t> wopstream;
+
+template<class CharT, class Traits>
+struct tuple_size<basic_pipe<Char, Traits>> {constexpr static std::size_t size = 2;};
+
+template<class CharT, class Traits> struct tuple_size<basic_pstream<Char, Traits>> {constexpr static std::size_t size = 2;};
+template<class CharT, class Traits> struct tuple_element<0, basic_pipe<Char, Traits>>  { using type = basic_ipstream <CharT, Traits>; },
+template<class CharT, class Traits> struct tuple_element<1, basic_pipe<Char, Traits>>  { using type = basic_opstream<CharT, Traits>; },
+
+template<std::size_t Index, class CharT, class Traits> auto get(      basic_pstream<Char, Traits> &&);
+template<std::size_t Index, class CharT, class Traits> auto get(const basic_pstream<Char, Traits>  &);
+
+template<class CharT, class Traits> basic_ipstream<CharT, Traits> get<0>(const basic_pstream<Char, Traits> &);
+template<class CharT, class Traits> basic_ipstream<CharT, Traits> get<0>(      basic_pstream<Char, Traits> &&);
+
+template<class CharT, class Traits> basic_opstream<CharT, Traits> get<1>(const basic_pstream<Char, Traits> &);
+template<class CharT, class Traits> basic_opstream<CharT, Traits> get<1>(      basic_pstream<Char, Traits> &&);
+
+
+class async_pipe;
+class async_pipe_read_end;
+class async_pipe_write_end;
+
+
+template<class CharT, class Traits>
+struct tuple_size<basic_pipe<Char, Traits>> {constexpr static std::size_t size = 2;};
+
+template<class CharT, class Traits> struct tuple_size<async_pipe> {constexpr static std::size_t size = 2;};
+template<class CharT, class Traits> struct tuple_element<0, async_pipe>  { using type = async_pipe_read_end; },
+template<class CharT, class Traits> struct tuple_element<1, async_pipe>  { using type = async_pipe_write_end; },
+
+template<std::size_t Index, class CharT, class Traits> auto get(      async_pipe &&);
+template<std::size_t Index, class CharT, class Traits> auto get(const async_pipe  &);
+
+template<class CharT, class Traits> async_pipe_read_end get<0>(const async_pipe &);
+template<class CharT, class Traits> async_pipe_read_end get<0>(      async_pipe &&);
+
+template<class CharT, class Traits> async_pipe_write_end get<1>(const async_pipe &);
+template<class CharT, class Traits> async_pipe_write_end get<1>(      async_pipe &&);
+
+}
+
+#+END_SRC c++
+
+** Classes ~basic_pipe_read_end~, ~basic_pipe_write_end~, ~basic_pipe~ Synopsis
+
+
+#+BEGIN_SRC c++
+
+namespace std
+{
+
+template<class CharT, class Traits = std::char_traits<CharT>>
+class basic_pipe_read_end
+{
+public:
+    typedef CharT                      char_type  ;
+    typedef          Traits            traits_type;
+    typedef typename Traits::int_type  int_type   ;
+    typedef typename Traits::pos_type  pos_type   ;
+    typedef typename Traits::off_type  off_type   ;
+    typedef implementation-defined native_handle_type;
+
+    /// Default construct the pipe_end. Will not be opened.
+    basic_pipe_read_end();
+
+    ///Construct a pipe_end from a implementation defined handle.
+    basic_pipe_read_end(native_handle_type handle);
+
+    /** Copy construct the pipe_end.
+     *  \note Duplicated the handles.
+     */
+    basic_pipe_read_end(basic_pipe_read_end& p);
+    /** Move construct the pipe_end. */
+    basic_pipe_read_end(basic_pipe_read_end&& lhs);
+    /** Copy assign the pipe_end.
+     *  \note Duplicated the handles.
+     */
+    basic_pipe_read_end& operator=(const basic_pipe_read_end& p);
+    /** Move assign the pipe_end. */
+    basic_pipe_read_end& operator=(basic_pipe_read_end&& lhs);
+    /** Destructor closes the handles. */
+    ~basic_pipe_read_end();
+    /** Get the native handle of the source. */
+    native_handle_type native_handle() const;
+
+    /** Assign a new value to the pipe_end */
+    void assign(native_handle_type h);
+  
+    ///Read data from the pipe_end.
+    int_type read(char_type * data, int_type count);
+    
+    ///Check if the pipe_end is open.
+    bool is_open();
+    ///Close the pipe_end
+    void close();
+};
+
+typedef basic_pipe_read_end<char>     pipe_read_end;
+typedef basic_pipe_read_end<wchar_t> wpipe_read_end;
+
+template<class CharT, class Traits = std::char_traits<CharT>>
+class basic_pipe_write_end
+{
+public:
+    typedef CharT                      char_type  ;
+    typedef          Traits            traits_type;
+    typedef typename Traits::int_type  int_type   ;
+    typedef typename Traits::pos_type  pos_type   ;
+    typedef typename Traits::off_type  off_type   ;
+    typedef implementation-defined native_handle_type;
+
+    /// Default construct the pipe_end. Will not be opened.
+    basic_pipe_write_end();
+
+    ///Construct a pipe_end from a implementation defined handle.
+    basic_pipe_write_end(native_handle_type handle);
+
+    /** Copy construct the pipe_end.
+     *  \note Duplicated the handles.
+     */
+    basic_pipe_write_end(basic_pipe_write_end& p);
+    /** Move construct the pipe_end. */
+    basic_pipe_write_end(basic_pipe_write_end&& lhs);
+    /** Copy assign the pipe_end.
+     *  \note Duplicated the handles.
+     */
+    basic_pipe_write_end& operator=(const basic_pipe_write_end& p);
+    /** Move assign the pipe_end. */
+    basic_pipe_write_end& operator=(basic_pipe_write_end&& lhs);
+    /** Destructor closes the handles. */
+    ~basic_pipe_write_end();
+    /** Get the native handle of the source. */
+    native_handle_type native_handle() const;
+
+    /** Assign a new value to the pipe_end */
+    void assign(native_handle_type h);
+
+    ///Write data to the pipe_end.
+    int_type write(const char_type * data, int_type count);
+    
+    ///Check if the pipe_end is open.
+    bool is_open();
+    ///Close the pipe_end
+    void close();
+};
+
+typedef basic_pipe_write_end<char>     pipe_write_end;
+typedef basic_pipe_write_end<wchar_t> wpipe_write_end;
 
 template<class CharT, class Traits = std::char_traits<CharT>>
 class basic_pipe
@@ -706,13 +905,22 @@ public:
     typedef typename Traits::int_type  int_type   ;
     typedef typename Traits::pos_type  pos_type   ;
     typedef typename Traits::off_type  off_type   ;
-    typedef ::boost::detail::winapi::HANDLE_ native_handle;
+    typedef implementation-defined native_handle;
+    
+    typedef basic_pipe_read_end<CharT, Traits> sink_type;
+    typedef basic_pipe_read_end<CharT, Traits> source_type;
+
+    ///Construct the pipe from two ends that are duplicated
+    basic_pipe(const source_type & source, const sink_type & sink);
+
+    ///Construct the pipe from two ends that are moved
+    basic_pipe(source_type && source, sink_type && sink);
 
     /// Default construct the pipe. Will be opened.
     basic_pipe();
 
     ///Construct a named pipe.
-    inline explicit basic_pipe(const std::string & name);
+    inline explicit basic_pipe(const std::filesystem::path & name);
     /** Copy construct the pipe.
      *  \note Duplicated the handles.
      */
@@ -727,34 +935,85 @@ public:
     basic_pipe& operator=(basic_pipe&& lhs);
     /** Destructor closes the handles. */
     ~basic_pipe();
-    /** Get the native handle of the source. */
-    native_handle native_source() const;
-    /** Get the native handle of the sink. */
-    native_handle native_sink  () const;
 
-    /** Assign a new value to the source */
-    void assign_source(native_handle h);
-    /** Assign a new value to the sink */
-    void assign_sink  (native_handle h);
+    ///Gives an lvalue reference to the sink 
+    sink_type && sink() &&;
 
+    ///Duplicates the sink 
+    sink_type sink() const &;
+
+    ///Gives an lvalue reference to the source 
+    source_type && source() &&;
+
+    ///Duplicates the source 
+    source_type source() const &;
 
     ///Write data to the pipe.
     int_type write(const char_type * data, int_type count);
     ///Read data from the pipe.
     int_type read(char_type * data, int_type count);
-    ///Check if the pipe is open.
+    ///Check if the pipe is open, i.e. both ends are open
+    
     bool is_open();
-    ///Close the pipe
+    ///Close both pipes end
     void close();
 };
 
-#endif
-
-
+//Stuff for C++17 aggregate initialization
 
 typedef basic_pipe<char>     pipe;
 typedef basic_pipe<wchar_t> wpipe;
 
+template<class CharT, class Traits> struct tuple_size<basic_pipe<Char, Traits>> {constexpr static std::size_t size = 2;};
+template<class CharT, class Traits> struct tuple_element<0, basic_pipe<Char, Traits>>  { using type = basic_pipe_read_end <CharT, Traits>; };
+template<class CharT, class Traits> struct tuple_element<1, basic_pipe<Char, Traits>>  { using type = basic_pipe_write_end<CharT, Traits>; };
+
+template<std::size_t Index, class CharT, class Traits> auto get(      basic_pipe<Char, Traits> &&);
+template<std::size_t Index, class CharT, class Traits> auto get(const basic_pipe<Char, Traits>  &);
+
+///Returns the read_end of the pipe, moved or duplicated depends on the pipe type.
+template<class CharT, class Traits> basic_pipe_read_end<CharT, Traits> get<0>(const basic_pipe<Char, Traits> &);
+template<class CharT, class Traits> basic_pipe_read_end<CharT, Traits> get<0>(      basic_pipe<Char, Traits> &&);
+
+///Returns the write_end of the pipe, moved or duplicated depends on the pipe type.
+template<class CharT, class Traits> basic_pipe_write_end<CharT, Traits> get<1>(const basic_pipe<Char, Traits> &);
+template<class CharT, class Traits> basic_pipe_write_end<CharT, Traits> get<1>(      basic_pipe<Char, Traits> &&);
+
+}
+
+#+END_SRC c++
+
+Compared to the ~boost.process~ implemenation, this version addes classes for different pipe_ends and uses C++17 aggregate initialization.
+The reason is that the following behaviour is not necessarily intuitive:
+
+#+BEGIN_SRC c++
+
+boost::process::pipe p;
+
+boost::process::child c("foo", boost::process::std_in < p);
+
+#+END_SRC
+
+In boost.process this closes the write end of ~p~, so an ~EOF~ is read from ~p~ when ~c~ exists. In most cases this would be expected behaviour, but it is far from obvious. 
+By using two different types this can be made more obvious, especially since aggregate initializtion can be used:
+
+#+BEGIN_SRC c++
+
+auto [p_read, p_write] = std::pipe();
+std::process("foo", std::process_io(p_read));
+p_read.close();
+
+p_write.write("data", 5);
+
+#+END_SRC
+
+Note that overloading allows us to either copy or move the pipe, i.e. the given example only moves the handles without duplicating them.
+
+
+** Classes ~basic_pipebuf~, ~basic_opstream~, ~basic_ipstream~ and ~basic_pstream~ Synopsis
+
+
+#+BEGIN_SRC c++
 
 /** Implementation of the stream buffer for a pipe.
  */
@@ -764,7 +1023,7 @@ template<
 >
 struct basic_pipebuf : std::basic_streambuf<CharT, Traits>
 {
-    typedef basic_pipe<CharT, Traits> pipe_type;
+    typedef basic_pipe<CharT, Traits> pipe_read_end;
 
     typedef           CharT            char_type  ;
     typedef           Traits           traits_type;
@@ -772,11 +1031,10 @@ struct basic_pipebuf : std::basic_streambuf<CharT, Traits>
     typedef  typename Traits::pos_type pos_type   ;
     typedef  typename Traits::off_type off_type   ;
 
-    constexpr static int default_buffer_size = BOOST_PROCESS_PIPE_SIZE;
+    constexpr static int default_buffer_size = implementation-defined;
 
     ///Default constructor, will also construct the pipe.
-    basic_pipebuf();this->setp(_write.data(), _write.data() + _write.size());
-    }
+    basic_pipebuf();
     ///Copy Constructor.
     basic_pipebuf(const basic_pipebuf & ) = default;
     ///Move Constructor
@@ -827,7 +1085,7 @@ struct basic_pipebuf : std::basic_streambuf<CharT, Traits>
     basic_pipebuf<CharT, Traits>* open();
 
     ///Open a new named pipe
-    basic_pipebuf<CharT, Traits>* open(const std::string & name);
+    basic_pipebuf<CharT, Traits>* open(const std::filesystem::path & name);
 
     ///Flush the buffer & close the pipe
     basic_pipebuf<CharT, Traits>* close();
@@ -847,7 +1105,8 @@ class basic_ipstream : public std::basic_istream<CharT, Traits>
 {
 public:
 
-    typedef basic_pipe<CharT, Traits> pipe_type;
+    typedef basic_pipe_read_end <CharT, Traits>          pipe_end_type;
+    typedef basic_pipe_write_end<CharT, Traits> opposite_pipe_end_type;
 
     typedef           CharT            char_type  ;
     typedef           Traits           traits_type;
@@ -858,17 +1117,17 @@ public:
     ///Get access to the underlying stream_buf
     basic_pipebuf<CharT, Traits>* rdbuf() const;
 
-    ///Default constructor.
+    ///Default constructor. Does not open a pipe
     basic_ipstream();
     ///Copy constructor.
     basic_ipstream(const basic_ipstream & ) = delete;
     ///Move constructor.
     basic_ipstream(basic_ipstream && lhs);
     ///Move construct from a pipe.
-    basic_ipstream(pipe_type && p);
+    basic_ipstream(pipe_end_type && p);
     
     ///Copy construct from a pipe.
-    basic_ipstream(const pipe_type & p);
+    basic_ipstream(const pipe_end_type & p);
 
     ///Copy assignment.
     basic_ipstream& operator=(const basic_ipstream & ) = delete;
@@ -876,29 +1135,29 @@ public:
     basic_ipstream& operator=(basic_ipstream && lhs);
     
     ///Move assignment of a pipe.
-    basic_ipstream& operator=(pipe_type && p);
+    basic_ipstream& operator=(pipe_end_type && p);
     
     ///Copy assignment of a pipe.
-    basic_ipstream& operator=(const pipe_type & p);
+    basic_ipstream& operator=(const pipe_end_type & p);
     
     ///Set the pipe of the streambuf.
-    void pipe(pipe_type&& p);
+    void pipe_end(pipe_end_type&& p);
     ///Set the pipe of the streambuf.
-    void pipe(const pipe_type& p);
+    void pipe_end(const pipe_end_type& p);
     ///Get a reference to the pipe.
-    pipe_type &      pipe() &;
+    pipe_end_type &      pipe_end() &;
     ///Get a const reference to the pipe.
-    const pipe_type &pipe() const &;
+    const pipe_end_type &pipe_end() const &;
     ///Get a rvalue reference to the pipe. Qualified as rvalue.
-    pipe_type &&     pipe()  &&;
+    pipe_end_type &&     pipe_end()  &&;
     ///Check if the pipe is open
     bool is_open() const;
 
     ///Open a new pipe
-    void open();
+    opposite_pipe_end_type open();
 
     ///Open a new named pipe
-    void open(const std::string & name);
+    opposite_pipe_end_type open(const std::filesystem::path & name);
 
     ///Flush the buffer & close the pipe
     void close();
@@ -917,8 +1176,9 @@ template<
 class basic_opstream : public std::basic_ostream<CharT, Traits>
 {
 public:
-    typedef basic_pipe<CharT, Traits> pipe_type;
-
+    typedef basic_pipe_write_end<CharT, Traits>          pipe_end_type;
+    typedef basic_pipe_read_end <CharT, Traits> opposite_pipe_end_type;
+    
     typedef           CharT            char_type  ;
     typedef           Traits           traits_type;
     typedef  typename Traits::int_type int_type   ;
@@ -938,10 +1198,10 @@ public:
     basic_opstream(basic_opstream && lhs);
     
     ///Move construct from a pipe.
-    basic_opstream(pipe_type && p);
+    basic_opstream(pipe_end_type && p);
     
     ///Copy construct from a pipe.
-    basic_opstream(const pipe_type & p);
+    basic_opstream(const pipe_end_type & p);
     
     ///Copy assignment.
     basic_opstream& operator=(const basic_opstream & ) = delete;
@@ -949,27 +1209,27 @@ public:
     basic_opstream& operator=(basic_opstream && lhs);
     
     ///Move assignment of a pipe.
-    basic_opstream& operator=(pipe_type && p);
+    basic_opstream& operator=(pipe_end_type && p);
     
     ///Copy assignment of a pipe.
-    basic_opstream& operator=(const pipe_type & p);
+    basic_opstream& operator=(const pipe_end_type & p);
     
-    ///Set the pipe of the streambuf.
-    void pipe(pipe_type&& p);
-    ///Set the pipe of the streambuf.
-    void pipe(const pipe_type& p);
-    ///Get a reference to the pipe.
-    pipe_type &      pipe() &;
-    ///Get a const reference to the pipe.
-    const pipe_type &pipe() const & {return _buf.pipe();}
-    ///Get a rvalue reference to the pipe. Qualified as rvalue.
-    pipe_type &&     pipe()  &&;
+    ///Set the pipe_end of the streambuf.
+    void pipe_end(pipe_end_type&& p);
+    ///Set the pipe_end of the streambuf.
+    void pipe_end(const pipe_end_type& p);
+    ///Get a reference to the pipe_end.
+    pipe_end_type &      pipe_end() &;
+    ///Get a const reference to the pipe_end.
+    const pipe_end_type &pipe_end() const &;
+    ///Get a rvalue reference to the pipe_end. Qualified as rvalue.
+    pipe_end_type &&     pipe_end()  &&;
 
     ///Open a new pipe
-    void open();
+    opposite_pipe_end_type open();
 
     ///Open a new named pipe
-    void open(const std::string & name);
+    opposite_pipe_end_type open(const std::filesystem::path & name);
 
     ///Flush the buffer & close the pipe
     void close();
@@ -1042,7 +1302,7 @@ public:
     void open();
 
     ///Open a new named pipe
-    void open(const std::string & name);
+    void open(const std::filesystem::path & name);
 
     ///Flush the buffer & close the pipe
     void close();
@@ -1052,7 +1312,192 @@ public:
 typedef basic_pstream<char>     pstream;
 typedef basic_pstream<wchar_t> wpstream;
 
+
+}
+
+#+END_SRC
+
+The structure of the streams reflects the pipe_end distinction of ~basic_pipe~. Additionally, the open function on the ~ipstream~ / ~opstream~ allows to open a full pipe and be handled by another class, e.g.:
+
+#+BEGIN_SRC c++
+std::ipstream is; //not opened
+std::opstream os{is.open()}; //now is & os point to the same pipe.
+#+END_SRC
+
+Or using aggregate initialization:
+
+#+BEGIN_SRC c++
+auto [is, os] = std::pstream();
+#+END_SRC
+
+Or to be used in a process
+
+#+BEGIN_SRC c++
+std::ipstream is; //not opened
+std::process proc("foo", std::process_io({}, is.open(), {})); //stdout can be read from is.
+#+END_SRC
+
+
+** Classes ~async_pipe_read_end~, ~async_pipe_write_end~, ~async_pipe~ Synopsis
+
+#+BEGIN_SRC c++
+
+
 ///The following is dependent on the networking TS
+namespace std 
+{
+
+class async_pipe_read_end
+{
+public:
+ /** Typedef for the native handle representation.
+     */
+    typedef platform_specific native_handle_type;
+
+    async_pipe_read_end(std::net::Executor & ios);
+    async_pipe_read_end(std::net::Executor & ios, native_handle_type native_handle);
+
+    /** Copy-Constructor of the async pipe end. */
+    async_pipe_read_end(const async_pipe_read_end& lhs);
+
+    /** Move-Constructor of the async pipe end.
+     */
+    async_pipe_read_end(async_pipe_read_end&& lhs);
+
+    /** Construct the async-pipe from a pipe end. */
+    template<class CharT, class Traits = std::char_traits<CharT>>
+    explicit async_pipe_read_end(std::net::Executor & ios, const basic_pipe_read_end<CharT, Traits> & p);
+
+    /** Assign a basic_pipe_read_end.
+     * @note Windows requires a named pipe for this, if a the wrong type is used an exception is thrown.
+     *
+     */
+    template<class CharT, class Traits = std::char_traits<CharT>>
+    inline async_pipe_read_end& operator=(const basic_pipe_read_end<CharT, Traits>& p);
+
+    /** Copy Assign a pipe end.
+     * @note Duplicates the handles.
+     */
+    async_pipe_read_end& operator=(const async_pipe_read_end& lhs);
+    /** Move assign a pipe end.*/
+    async_pipe_read_end& operator=(async_pipe_read_end&& lhs);
+
+    /** Destructor. Closes the pipe handles. */
+    ~async_pipe_read_end();
+
+    /** Explicit cast to basic_pipe.  */
+    template<class CharT, class Traits = std::char_traits<CharT>>
+    inline explicit operator basic_pipe_read_end<CharT, Traits>() const;
+    
+    /** Open the pipe */
+    template<typename CharT = char, typename Traits = std::char_traits<CharT>>
+    basic_pipe_write_end<CharT, Traits> open();
+
+    /** Open the pipe */
+    template<typename CharT = char, typename Traits = std::char_traits<CharT>>
+    basic_pipe_write_end<CharT, Traits> open(const std::filesystem::path & str);
+
+
+
+    /** Cancel the current asynchronous operations. */
+    void cancel();
+    /** Close the pipe handle. */
+    void close();
+
+    /** Check if the pipe end is open. */
+    bool is_open() const;
+
+    /** Read some data from the handle.  */
+    template<typename MutableBufferSequence>
+    std::size_t read_some(const MutableBufferSequence & buffers);
+
+    /** Get the native handle of the source. */
+    native_handle_type native_handle() const;
+
+    /** Start an asynchronous read.*/
+    template<typename MutableBufferSequence,
+             typename ReadHandler>
+    implemtation-defined async_read_some(
+        const MutableBufferSequence & buffers,
+              ReadHandler &&handler);
+};
+
+
+class async_pipe_write_end
+{
+public:
+ /** Typedef for the native handle representation.
+     */
+    typedef platform_specific native_handle_type;
+
+    async_pipe_write_end(std::net::Executor & ios);
+    async_pipe_write_end(std::net::Executor & ios, native_handle_type native_handle);
+
+    /** Copy-Constructor of the async pipe end. */
+    async_pipe_write_end(const async_pipe_write_end& lhs);
+
+    /** Move-Constructor of the async pipe end.
+     */
+    async_pipe_write_end(async_pipe_write_end&& lhs);
+
+    /** Construct the async-pipe from a pipe end. */
+    template<class CharT, class Traits = std::char_traits<CharT>>
+    explicit async_pipe_write_end(std::net::Executor & ios, const basic_pipe_write_end<CharT, Traits> & p);
+
+    /** Assign a basic_pipe_write_end.
+     * @note Windows requires a named pipe for this, if a the wrong type is used an exception is thrown.
+     *
+     */
+    template<class CharT, class Traits = std::char_traits<CharT>>
+    inline async_pipe_write_end& operator=(const basic_pipe_write_end<CharT, Traits>& p);
+
+    /** Copy Assign a pipe end.
+     * @note Duplicates the handles.
+     */
+    async_pipe_write_end& operator=(const async_pipe_write_end& lhs);
+    /** Move assign a pipe end.*/
+    async_pipe_write_end& operator=(async_pipe_write_end&& lhs);
+
+    /** Destructor. Closes the pipe handles. */
+    ~async_pipe_write_end();
+
+    /** Explicit cast to basic_pipe.  */
+    template<class CharT, class Traits = std::char_traits<CharT>>
+    inline explicit operator basic_pipe_write_end<CharT, Traits>() const;
+    
+    /** Open the pipe */
+    template<typename CharT = char, typename Traits = std::char_traits<CharT>>
+    basic_pipe_read_end<CharT, Traits> open();
+
+    /** Open the pipe */
+    template<typename CharT = char, typename Traits = std::char_traits<CharT>>
+    basic_pipe_read_end<CharT, Traits> open(const std::filesystem::path & str);
+
+    /** Cancel the current asynchronous operations. */
+    void cancel();
+    /** Close the pipe handle. */
+    void close();
+
+    /** Check if the pipe end is open. */
+    bool is_open() const;
+
+    /** Write some data to the handle.  */
+    template<typename MutableBufferSequence>
+    std::size_t write_some(const MutableBufferSequence & buffers);
+    
+    /** Get the native handle of the source. */
+    native_handle_type native_handle() const;
+
+    /** Start an asynchronous write.*/
+    template<typename ConstBufferSequence,
+             typename WriteHandler>
+    implemtation-defined async_write_some(
+        const ConstBufferSequence & buffers,
+        WriteHandler && handler);
+};
+
+
+
 
 /** Class implementing and asnychronous I/O-Object for use with the networking TEST.
  *
@@ -1082,7 +1527,7 @@ public:
      *
      * @note Windows restricts possible names.
      */
-    inline async_pipe(std::net::Executor & ios, const std::string & name);
+    inline async_pipe(std::net::Executor & ios, const std::filesystem::path & name);
 
     /** Copy-Constructor of the async pipe.
      * @note Windows requires a named pipe for this, if a the wrong type is used an exception is thrown.
@@ -1101,14 +1546,20 @@ public:
     template<class CharT, class Traits = std::char_traits<CharT>>
     explicit async_pipe(std::net::Executor & ios, const basic_pipe<CharT, Traits> & p);
 
-
-
     /** Assign a basic_pipe.
      * @note Windows requires a named pipe for this, if a the wrong type is used an exception is thrown.
      *
      */
     template<class CharT, class Traits = std::char_traits<CharT>>
     inline async_pipe& operator=(const basic_pipe<CharT, Traits>& p);
+
+    ///Returns a copied pipe read end
+    const async_pipe_read_end  & read_end() const &;
+          async_pipe_read_end && read_end() &&;
+
+    ///Returns a copied pipe write end
+    const async_pipe_write_end  & write_end() const &;
+          async_pipe_write_end && write_end() &&;
 
     /** Copy Assign a pipe.
      * @note Duplicates the handles.
@@ -1126,17 +1577,11 @@ public:
 
     /** Cancel the current asynchronous operations. */
     void cancel();
-    void cancel_sink();
-    void cancel_source();
     /** Close the pipe handles. */
     void close();
-    void close_sink();
-    void close_source();
 
     /** Check if the pipes are open. */
     bool is_open() const;
-    bool is_sink_open() const;
-    bool is_source_open() const;
 
     /** Read some data from the handle.
 
@@ -1173,13 +1618,50 @@ public:
 
 };
 
+template<class CharT, class Traits> struct tuple_size<async_pipe> {constexpr static std::size_t size = 2;};
+template<class CharT, class Traits> struct tuple_element<0, async_pipe>  { using type = async_pipe_read_end ; };
+template<class CharT, class Traits> struct tuple_element<1, async_pipe>  { using type = async_pipe_write_end; };
+
+template<std::size_t Index, class CharT, class Traits> auto get(      async_pipe &&);
+template<std::size_t Index, class CharT, class Traits> auto get(const async_pipe  &);
+
+///Returns the read_end of the pipe, moved or duplicated depends on the pipe type.
+template<class CharT, class Traits> async_pipe_read_end get<0>(const async_pipe &);
+template<class CharT, class Traits> async_pipe_read_end get<0>(      async_pipe &&);
+
+///Returns the write_end of the pipe, moved or duplicated depends on the pipe type.
+template<class CharT, class Traits> basic_pipe_write_end get<1>(const async_pipe &);
+template<class CharT, class Traits> basic_pipe_write_end get<1>(      async_pipe &&);
 
 }
 #+END_SRC
 
+~asnyc_pipe~ is structured similar to the ~basic_pipe~ triple. The ~async_pipe_end*::open~ returns a `basic_pipe_end_*` to the other side. This allows to use it in a process or to construct an opposite async_pipe:
+
+#+BEGIN_SRC c++
+std::net::system_executor exec;
+std::async_pipe_read_end ip{exec}; //not opened
+std::async_pipe_read_end op{exec, ip.open()}; //now re & os point to the same pipe, though can use different executors.
+#+END_SRC
+
+Or using aggregate initialization:
+
+#+BEGIN_SRC c++
+std::net::system_executor exec;
+auto [ip, op] = std::async_pipe(exec);
+#+END_SRC
+
+Or to be used in a process
+
+#+BEGIN_SRC c++
+std::net::system_executor exec;
+std::async_pipe_read_end ip{exec}; 
+std::process proc("foo", std::process_io({}, ip.open(), {}));
+#+END_SRC
+
 ** Header ~<this_process>~ synposis
 
-This header provides information about the current process
+This header provides information about the current process.
 
 #+BEGIN_SRC c++
 

--- a/process_proposal.org
+++ b/process_proposal.org
@@ -295,6 +295,9 @@ namespace std {
            {launcher.launch(filesystem::path(), vector<string>())} -> process; //refine that so check tha parameter list, good enough for now.
    };
    
+   //The default process-launcher of the impementation
+   class process_launcher;
+   
    //An initializer is an object that changes the behavior of a process during launch and thus listens to at least one of the hooks of the launcher. 
    //Note that the following example only uses portable hooks, but non portables might suffic as well
    template<typename Init, ProcessLauncher Launcher = process_launcher>
@@ -330,7 +333,6 @@ namespace std {
       
 }
 #+END_SRC
-
 
 ** Class ~process~
 

--- a/process_proposal.org
+++ b/process_proposal.org
@@ -936,17 +936,22 @@ public:
     /** Destructor closes the handles. */
     ~basic_pipe();
 
+    ///Gives an rvalue reference to the source 
+          write_end_type  & write_end() &;
+
     ///Gives an lvalue reference to the sink 
-    write_end_type && write_end() &&;
+          write_end_type && write_end() &&;
 
     ///Duplicates the sink 
-    write_end_type write_end() const &;
+    const write_end_type  & write_end() const &;
 
+    ///Gives an rvalue reference to the source 
+          read_end_type  & read_end() &;
     ///Gives an lvalue reference to the source 
-    read_end_type && read_end() &&;
+          read_end_type && read_end() &&;
 
     ///Duplicates the source 
-    read_end_type read_end() const &;
+    const read_end_type  & read_end() const &;
 
     ///Write data to the pipe.
     int_type write(const char_type * data, int_type count);
@@ -1072,11 +1077,11 @@ struct basic_pipebuf : std::basic_streambuf<CharT, Traits>
     ///Set the pipe of the streambuf.
     void pipe(const pipe_type& p);
     ///Get a reference to the pipe.
-    pipe_type &      pipe() &;
+          pipe_type &      pipe() &;
     ///Get a const reference to the pipe.
-    const pipe_type &pipe() const & {return _pipe;}
+    const pipe_type &pipe() const &;
     ///Get a rvalue reference to the pipe. Qualified as rvalue.
-    pipe_type &&     pipe()  &&;
+          pipe_type &&     pipe()  &&;
 
     ///Check if the pipe is open
     bool is_open() const ;

--- a/process_proposal.org
+++ b/process_proposal.org
@@ -374,6 +374,9 @@ class process
     // return code of the process, only valid if !running()
     int exit_code() const;
 
+    // return the system native exit code. That is on linux it contains the reason of the exit, such as can be detected by WIFSIGNALED 
+    int native_exit_code() const;
+
 
     // check if the process is running. If the process has exited already, it might store the exit_code internally.
     bool running() const;
@@ -389,6 +392,7 @@ class process
 
     // detach a spawned process -- let it run after this handle destructs
     void detach();
+
 
     /** TODO clean... Terminate the child process. 
     *

--- a/process_proposal.org
+++ b/process_proposal.org
@@ -937,16 +937,16 @@ public:
     ~basic_pipe();
 
     ///Gives an lvalue reference to the sink 
-    sink_type && sink() &&;
+    write_end_type && write_end() &&;
 
     ///Duplicates the sink 
-    sink_type sink() const &;
+    write_end_type write_end() const &;
 
     ///Gives an lvalue reference to the source 
-    source_type && source() &&;
+    read_end_type && read_end() &&;
 
     ///Duplicates the source 
-    source_type source() const &;
+    read_end_type read_end() const &;
 
     ///Write data to the pipe.
     int_type write(const char_type * data, int_type count);

--- a/process_proposal.org
+++ b/process_proposal.org
@@ -330,6 +330,12 @@ namespace std {
    
    //Satisfies ProcessInitializer
    class process_limit_handles;
+   
+   
+   //Inherits std::system_error
+   /** Can have a a std::filesystem::path attached to it, when failing before launch, or a pid_t after launch.
+   */
+   class process_error;
       
 }
 #+END_SRC
@@ -1263,6 +1269,11 @@ namespace std::this_process
             entry();
             entry(const entry &);
             entry(entry &&);
+            
+            entry(const std::string  &);
+            entry(const std::wstring &);
+            
+            entry(const std::vector<value_type>  &);
         
             entry& operator=(const entry &);
             entry& operator=(entry &&);

--- a/process_proposal.org
+++ b/process_proposal.org
@@ -1271,6 +1271,162 @@ namespace std::this_process
 
 #+END_SRC
 
+* Design discussion & Examples
+
+** Concept ~ProcessLauncher~
+
+The process launcher is a class that impements the actual launch of a process. In most cases there are different versions to do this. On linux for example, ~vfork~ can be required as an alternative for fork on low-memory devices. And while posix can change a user by utilizing setuid in a ProcessInitializer, windows requires the invocation of a different function (CreateProcessAsUserA).
+
+As an example for linux:
+
+#+BEGIN_SRC c++
+
+#include <gnu_cxx_process>
+
+__gnu_cxx::vfork_launcher launcher;
+std::process my_proc("/bin/programm", {}, launcher);
+
+#+END_SRC
+
+or for windows:
+
+#+BEGIN_SRC c++
+
+__msvc::as_user_launcher{"1234-is-not-a-safe-user-token"};
+std::process my_proc("C:\program", {}, launcher);
+
+#+END_SRC
+
+In addition libraries may provide their launchers. The requirement is that there is an actual process with a pid as the result of launching the process.
+
+Furthermore, the fact that the launcher has a well-specified ~launch~ function allows to launch a process like this:
+
+#+BEGIN_SRC c++
+
+std::process_launcher launcher;
+auto proc = launcher.launch("/bin/foo", {});
+
+#+END_SRC
+
+Both versions make sense in their own way: on the one hand using the process constructor fits well in with the STL and it's RAII classes like thread. On the other hand it actually uses a factory-class, which can be used so explicitly.
+
+** Concept ~ProcessInitializer~
+
+The process initializer is a class that modifies the behaviour of a process. There is no guarantee that a custom initializer is portable, i.e. it will not only be dependable on the operating system but also on the process launcher. This is because an initializer might need to modify members of the launcher itself (common on windows) and thus might break with another launcher.
+
+Note that the concept might look different on other implementation, since additional event hooks might exist.
+
+#+BEGIN_SRC c++
+
+struct switch_user
+{
+	::uid_t uid;
+
+	tempalte<ProcessLauncher Launcher>
+	//Linux specific event, after the successful fork, called from the child process
+	void on_exec_setup(Launcher &)
+	{
+        ::setuid(this->uid);
+    }
+};
+
+std::process proc("/bin/spyware", {}, switch_user{42});
+
+#+END_SRC
+
+** Class ~process~
+
+*** Constructor ~process(std::filesystem::path, std::ranges::Range<String>, Inits...init)~
+
+This is the default launching function, and forwards to the ~std::process_launcher~. boost.process supports a cmd-style execution (similar to ~std::system~), which we opted to remove from this library. This is because the syntax obscures what the library actually does, while introducing a security risk (shell injection). Instead we require the actually used (absolute) path of the executable. Since it is common to just type a command and expect the shell to search for the executabe in the ~PATH~ environment variable, there is a helper function for that. Either in the ~std::environment~ class or the ~std::this_process::environment~ namespace.
+
+#+BEGIN_SRC
+
+std::system("git --version"); //launches to cmd or /bin/sh
+
+std::process("git", {"--version"}); //does err, exe not found
+std::process(std::this_process::environment::find_executable("git"), {"--version"}); //finds the exe
+
+//Or if we want to run it through the shell, note that /c is windows specific
+std::process(std::this_process::environment::shell(), {"/c", "git --version"});
+
+#+END_SRC
+
+
+Another solution is for a user to provide their own ~ProcessLauncher~ as a ~ShellLauncher~.
+
+*** function ~wait~
+
+The wait function waits for a process to exit. When replacing ~std::system~ it can be used like this:
+
+#+BEGIN_SRC c++
+const auto result_sys = std::system("gcc --version");
+
+
+std::process proc(std::this_process::environment::find_executable("gcc"), {"--version"});
+proc.wait();
+const auto result_proc = proc.exit_code();
+
+#+END_SRC
+
+*** function ~wait_for~
+
+In case the child process might hang, ~wait_for~ might be used.
+
+#+BEGIN_SRC c++
+
+std::process proc(std::this_process::environment::find_executable("python"), {"--version"});
+
+int res = -1;
+if (proc.wait_for(std::chrono::seconds(1))
+    res = proc.exit_code();
+else
+    proc.terminate(); 
+
+#+END_SRC
+
+*** function ~native_handle~
+
+Since there is a lot funcitonality that is not portable, the ~native_handle~ is accessible. For example, there is no clear equivalent for ~SIGTERM~ on windows. If a user still wants to use this, he might still do so:
+
+#+BEGIN_SRC c++
+
+std::process proc("/usr/bin/python", {});
+
+::kill(proc.native_handle(), SIGTERM);
+proc.wait();
+
+#+END_SRC
+
+*** function ~native_exit_code~
+
+The exit-code may contain more information on a specific system. Practically this is the case on posix. If a user wants to extract additional information he might need to use ~native_exit_code~.
+
+#+BEGIN_SRC c++
+
+std::process proc(std::this_process::environment::find_executable("gcc"), {});
+proc.wait();
+const auto exit_code = proc.exit_code(); //equals 1, since no input files
+
+//Linux specific:
+const exited_normally = WIFEXITED(proc.native_exit_code();
+
+#+END_SRC
+
+*** function ~async_wait~
+
+To allow asynchronous operations, the process library shall integrate with the networking TS.
+
+#+BEGIN_SRC
+
+extern std::net::system_executor exec;
+std::process proc(std::this_environment::find_executable("gcc"), {});
+
+auto fut = proc.async_wait(exec, std::net::use_future_t());
+const exit_code = fut.get();
+assert(exit_code == proc.exit_code());
+#+END_SRC
+
 * Open Questions
 ** if we don't have wait_for can we still detach? 
 

--- a/process_proposal.org
+++ b/process_proposal.org
@@ -410,7 +410,7 @@ class process
     
     //The following is dependent on the networking TS. CompletionToken has the signature (int, std::error_code), i.e. wait for the process to exit and get the exit_code if exited. 
     template<class CompletionToken>
-    DEDUCED async_wait(std::io_context & ctx, CompletionToken&& token);
+    DEDUCED async_wait(std::net::Executor & ctx, CompletionToken&& token);
 };
 #+END_SRC
 
@@ -488,11 +488,11 @@ class process_group
     
     //The following is dependent on the networking TS. CompletionToken has the signature (std::error_code) and waits for all processes to exit
     template<class CompletionToken>
-    DEDUCED async_wait(std::io_context & ctx, CompletionToken&& token);
+    DEDUCED async_wait(std::net::Executor & ctx, CompletionToken&& token);
 
     //The following is dependent on the networking TS. CompletionToken has the signature (std::error_code) and waits for one process
     template<class CompletionToken>
-    DEDUCED async_wait_one(std::io_context & ctx, CompletionToken&& token);
+    DEDUCED async_wait_one(std::net::Executor & ctx, CompletionToken&& token);
 
 };
 #+END_SRC
@@ -1045,18 +1045,18 @@ public:
      */
 
     /** Construct a new async_pipe, does automatically open the pipe.
-     * Initializes source and sink with the same io_context.
+     * Initializes source and sink with the same net::Executor.
      * @note Windows creates a named pipe here, where the name is automatically generated.
      */
-    inline async_pipe(std::io_context & ios);
+    inline async_pipe(std::net::Executor & ios);
 
 
     /** Construct a new async_pipe, does automatically open.
-     * Initializes source and sink with the same io_context.
+     * Initializes source and sink with the same net::Executor.
      *
      * @note Windows restricts possible names.
      */
-    inline async_pipe(std::io_context & ios, const std::string & name);
+    inline async_pipe(std::net::Executor & ios, const std::string & name);
 
     /** Copy-Constructor of the async pipe.
      * @note Windows requires a named pipe for this, if a the wrong type is used an exception is thrown.
@@ -1073,7 +1073,7 @@ public:
      *
      */
     template<class CharT, class Traits = std::char_traits<CharT>>
-    explicit async_pipe(std::io_context & ios, const basic_pipe<CharT, Traits> & p);
+    explicit async_pipe(std::net::Executor & ios, const basic_pipe<CharT, Traits> & p);
 
 
 


### PR DESCRIPTION
Heya, I was rethinking the pipe design from `boost.process` and since C++17 allows us aggregate initialization I wrote up my thoughts how I would do that now. I hope the diff explains it properly, but here is the basic idea:

Currently there is a pipe object, holding a pair of ints or a pair of `HANDLE`.

Any pipe stream when default-constructed holds an open pipe, so you can do this:

```cpp
ipstream is;
process proc(..., stdio({}, is,{});
```

The weird part is that `is` hold a full pipe and the the process start closes the write end (in `boost.process`)

I am now thinking about changing this design slightly, so we have pipe_ends, i.e. pipe_end_read, pipe_end_write. This would clarify a lot of things, especially when you want to close one pipe end.

I.e.: 
```cpp
optional<pipe> p = pipe();
process proc(..., stdio({}, p.write_end(), {}));

pipe_end_write wr = std::move(p);
p = nullopt;
```

This way it is very obvious which part of the pipe is open and which isn't. Note that dangling pipe handles can cause deadlocks.

Now, when we apply this for streams, then pstream would hold a pipe (can be opened on ctor call). ipstream / optream would hold a pipe_end each, so they could not be default constructed, i.e. the pipe would be closed. 
This would NOT allow you to do this:

```cpp
ipstream is;
process(..., stdio({} , is, {}));
```

BUT, I would add an open function that returns the other pipe_end, i.e.

```cpp
std::ipstream::open() -> std::pipe_end_read;
std::opstream::open() -> std::pipe_end_write;
```

Meaning you can write:

```cpp
ipstream is;
opstream os;

process(..., stdio(os.open(), is.open(), ()));
```

Secondly I would add decomposition.

```cpp
auto [p_read, p_write] = std::pipe();
auto [is, os] = std::pstream(); 

std::net::system_exector exec;
auto [ap_read, ap_write] = std::async_pipe(exec);
```